### PR TITLE
feat: make InitLogger option-based with flexible outputs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,8 +15,11 @@ go test ./...
 go test -v ./path/to/file_test.go -run TestFunctionName
 
 # Run examples
-go run example/withContext/main.go
-go run example/noContext/main.go
+go run ./example/basic
+go run ./example/file
+go run ./example/teeJSON
+go run ./example/withContext
+go run ./example/noContext
 
 # Lint
 go vet ./...
@@ -75,6 +78,14 @@ func DebugContext(ctx context.Context, msg string, fields ...zapcore.Field)
 func Debug(msg string, fields ...zapcore.Field)
 ```
 
+`InitLogger` takes only options (all optional):
+```go
+func InitLogger(opts ...Option) error
+// defaults: level=info, output=stdout
+```
+
+`Named()` returns `*otelzap.Logger` and bypasses package-level statistics / trace_id / auto events — document this in GoDoc; do not wrap it.
+
 ### OpenTelemetry Integration
 - Use `otelzap.Logger` for tracing-aware logging
 - Initialize metrics in `init()` function: `otel.GetMeterProvider().Meter("zaplog")`
@@ -88,8 +99,9 @@ func Debug(msg string, fields ...zapcore.Field)
 ### GoDoc Comments
 Exported functions must have GoDoc comments:
 ```go
-// InitLogger initializes the default logger with the specified configuration.
-func InitLogger(logPath string, level string, opts ...Option)
+// InitLogger initializes the default logger.
+// Defaults: level=info, output=stdout. Returns an error on invalid config.
+func InitLogger(opts ...Option) error
 ```
 
 ### Constants & Globals
@@ -112,12 +124,24 @@ var (
 ```
 zaplog/
 ├── zaplog.go           # Main package exports, logging functions
-├── option.go           # Functional options for configuration
+├── option.go           # Functional options for InitLogger
 ├── otel_metrics.go     # OpenTelemetry metrics initialization
-├── example/            # Usage examples
-│   ├── withContext/main.go
-│   └── noContext/main.go
-└── go.mod              # Go module definition (Go 1.24)
+├── example/            # Usage examples (see example/README.md)
+│   ├── basic/          # defaults, SetLevel, Sync, Named
+│   ├── file/           # WithFile + rotation
+│   ├── teeJSON/        # file + stdout + JSON
+│   ├── noContext/      # metrics demo
+│   └── withContext/    # trace_id / auto events demo
+└── go.mod
+```
+
+## Run examples
+```bash
+go run ./example/basic
+go run ./example/file
+go run ./example/teeJSON
+go run ./example/noContext
+go run ./example/withContext
 ```
 
 ## Key Dependencies

--- a/README.md
+++ b/README.md
@@ -1,78 +1,89 @@
 # zaplog
 
-Simple packaging for [zap](https://github.com/uber-go/zap)
+Simple packaging for [zap](https://github.com/uber-go/zap) with OpenTelemetry hooks.
 
-## Usage
+## Install
+
+```bash
+go get github.com/vearne/zaplog
 ```
+
+## Init
+
+```go
+// defaults: level=info, output=stdout
+zlog.InitLogger()
+
+// file only
+zlog.InitLogger(zlog.WithFile("/var/log/app.log"), zlog.WithLevel("debug"))
+
+// file + stdout, JSON (typical container setup)
+zlog.InitLogger(
+    zlog.WithFile("/var/log/app.log"),
+    zlog.WithStdout(),
+    zlog.WithJSON(),
+    zlog.WithLevel("info"),
+)
+
+defer zlog.Sync()
+```
+
+### Options
+
+| Option | Meaning |
+|--------|---------|
+| `WithLevel(string)` | debug / info / warn / error (default info) |
+| `WithFile(path)` | lumberjack file output |
+| `WithStdout()` / `WithStderr()` | std sinks |
+| `WithJSON()` | JSON encoder instead of console |
+| `WithCallerSkip(n)` | extra caller frames to skip (default 1) |
+| `WithTraceID` / `WithAutoEvents` | OTEL helpers |
+| `WithMaxSize` / `WithMaxAge` / `WithMaxBackups` / `WithCompress` | rotation |
+
+**Output rule:** if no output option is set, **stdout** is used. Once any of
+`WithFile` / `WithStdout` / `WithStderr` is set, only those sinks are enabled.
+
+### Runtime
+
+```go
+zlog.SetLevel("debug")
+_ = zlog.Sync() // flush before exit
+```
+
+### Named
+
+`Named()` returns `*otelzap.Logger` and **bypasses** package helpers
+(`statistics` / `trace_id` / auto span events). Use package-level
+`Info` / `InfoContext` when you need those.
+
+## Examples
+
+Runnable demos live under [`example/`](./example). See [`example/README.md`](./example/README.md).
+
+```bash
+go run ./example/basic
+go run ./example/file
+go run ./example/teeJSON
+go run ./example/noContext      # + Prometheus on :9090
+go run ./example/withContext   # + trace_id / span events
+```
+
+## Minimal snippet
+
+```go
 package main
 
 import (
-	"context"
-	"fmt"
-	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/promhttp"
 	zlog "github.com/vearne/zaplog"
-	"go.opentelemetry.io/otel"
-	otelProm "go.opentelemetry.io/otel/exporters/prometheus"
-	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
 	"go.uber.org/zap"
-	"net/http"
-	"sync/atomic"
-	"time"
 )
 
-var ops1 uint64
-var ops2 uint64
-
 func main() {
-	InitMeterProvider()
-
-	zlog.InitLogger("/tmp/withContext.log", "debug")
-	go func() {
-		//logger1 := zlog.Named("worker1")
-		ctx := context.Background()
-		for {
-			atomic.AddUint64(&ops1, 1)
-
-			zlog.InfoContext(ctx, "test info1", zap.Uint64("ops", atomic.LoadUint64(&ops1)))
-			zlog.WarnContext(ctx, "test warn1", zap.Uint64("ops", atomic.LoadUint64(&ops1)))
-			zlog.ErrorContext(ctx, "test error1", zap.Uint64("ops", atomic.LoadUint64(&ops1)))
-			time.Sleep(200 * time.Millisecond)
-		}
-
-	}()
-	go func() {
-		//logger2 := zlog.Named("worker2")
-		ctx := context.Background()
-		for {
-			atomic.AddUint64(&ops2, 1)
-
-			zlog.InfoContext(ctx, "test info2", zap.Uint64("ops", atomic.LoadUint64(&ops2)))
-			zlog.WarnContext(ctx, "test warn2", zap.Uint64("ops", atomic.LoadUint64(&ops2)))
-			zlog.ErrorContext(ctx, "test error2", zap.Uint64("ops", atomic.LoadUint64(&ops2)))
-			time.Sleep(200 * time.Millisecond)
-		}
-	}()
-
-	http.Handle("/metrics", promhttp.Handler())
-	fmt.Println("starting...")
-	// http://localhost:9090/metrics
-	http.ListenAndServe(":9090", nil)
-}
-
-func InitMeterProvider() *sdkmetric.MeterProvider {
-	promExporter, err := otelProm.New(otelProm.WithNamespace("otel-metrics"),
-		otelProm.WithRegisterer(prometheus.DefaultRegisterer),
-	)
-	if err != nil {
+	if err := zlog.InitLogger(); err != nil {
 		panic(err)
 	}
-	mp := sdkmetric.NewMeterProvider(
-		sdkmetric.WithReader(promExporter),
-		//sdkmetric.WithResource(initResource()),
-	)
-	otel.SetMeterProvider(mp)
+	defer zlog.Sync()
 
-	return mp
+	zlog.Info("hello", zap.String("from", "zaplog"))
 }
 ```

--- a/example/README.md
+++ b/example/README.md
@@ -1,0 +1,44 @@
+# Examples
+
+Run from the module root (`github.com/vearne/zaplog`).
+
+| Dir | What it shows | Command |
+|-----|---------------|---------|
+| [`basic`](./basic) | `InitLogger()` defaults, `SetLevel`, `Sync`, `Named` | `go run ./example/basic` |
+| [`file`](./file) | `WithFile` + rotation; auto-create parent dirs | `go run ./example/file` |
+| [`teeJSON`](./teeJSON) | File + stdout tee, JSON encoder (container-friendly) | `go run ./example/teeJSON` |
+| [`noContext`](./noContext) | Non-context logs + Prometheus `log_total` metrics | `go run ./example/noContext` |
+| [`withContext`](./withContext) | `InfoContext` + `WithTraceID` / `WithAutoEvents` | `go run ./example/withContext` |
+
+## Quick start
+
+```bash
+# zero-config: info → stdout
+go run ./example/basic
+
+# file only
+go run ./example/file
+
+# JSON to stdout and file
+go run ./example/teeJSON
+```
+
+## Init cheat sheet
+
+```go
+zlog.InitLogger() // level=info, stdout
+
+zlog.InitLogger(zlog.WithFile("/var/log/app.log"), zlog.WithLevel("debug"))
+
+zlog.InitLogger(
+    zlog.WithFile("/var/log/app.log"),
+    zlog.WithStdout(),
+    zlog.WithJSON(),
+)
+
+zlog.SetLevel("debug")
+defer zlog.Sync()
+```
+
+**Output rule:** if you pass no `WithFile` / `WithStdout` / `WithStderr`, stdout is used.
+As soon as any of those is set, only the sinks you listed are enabled.

--- a/example/basic/main.go
+++ b/example/basic/main.go
@@ -1,0 +1,40 @@
+// Basic usage: zero-config InitLogger (default level=info, output=stdout),
+// runtime SetLevel, and Sync on exit.
+//
+//	go run ./example/basic
+package main
+
+import (
+	"fmt"
+	"time"
+
+	zlog "github.com/vearne/zaplog"
+	"go.uber.org/zap"
+)
+
+func main() {
+	// No options → level=info, write to stdout.
+	if err := zlog.InitLogger(); err != nil {
+		panic(err)
+	}
+	defer zlog.Sync()
+
+	zlog.Info("app started", zap.String("env", "dev"))
+	zlog.Debug("this debug line is dropped (level=info)")
+	zlog.Warn("disk almost full", zap.Float64("used_pct", 92.5))
+
+	// Raise verbosity at runtime.
+	if err := zlog.SetLevel("debug"); err != nil {
+		panic(err)
+	}
+	zlog.Debug("debug enabled after SetLevel")
+
+	// Named() returns *otelzap.Logger and bypasses package helpers
+	// (statistics / trace_id / auto span events). Prefer package-level
+	// Info/InfoContext when you need those features.
+	worker := zlog.Named("worker")
+	worker.Info("named logger still works", zap.Int("n", 1))
+
+	fmt.Println("--- done ---")
+	time.Sleep(10 * time.Millisecond)
+}

--- a/example/file/main.go
+++ b/example/file/main.go
@@ -1,0 +1,37 @@
+// File-only logging with rotation options.
+// Parent directories are created automatically when missing.
+//
+//	go run ./example/file
+package main
+
+import (
+	"os"
+	"path/filepath"
+
+	zlog "github.com/vearne/zaplog"
+	"go.uber.org/zap"
+)
+
+func main() {
+	logPath := filepath.Join(os.TempDir(), "zaplog-example", "app.log")
+
+	// WithFile alone disables the default stdout sink.
+	if err := zlog.InitLogger(
+		zlog.WithFile(logPath),
+		zlog.WithLevel("debug"),
+		zlog.WithMaxSize(1),    // MB
+		zlog.WithMaxBackups(3),
+		zlog.WithMaxAge(7),     // days
+		zlog.WithCompress(false),
+	); err != nil {
+		panic(err)
+	}
+	defer zlog.Sync()
+
+	zlog.Debug("debug to file", zap.String("path", logPath))
+	zlog.Info("info to file")
+	zlog.Warn("warn to file")
+	zlog.Error("error to file", zap.String("hint", "check the log file"))
+
+	println("wrote logs to", logPath)
+}

--- a/example/noContext/main.go
+++ b/example/noContext/main.go
@@ -1,7 +1,12 @@
+// Non-context logging + OpenTelemetry metrics (log_total counter).
+//
+//	go run ./example/noContext
+//	curl http://localhost:9090/metrics | grep log_total
 package main
 
 import (
 	"fmt"
+	"log"
 	"net/http"
 	"sync/atomic"
 	"time"
@@ -19,26 +24,34 @@ var ops1 uint64
 var ops2 uint64
 
 func main() {
-	InitMeterProvider()
+	initMeterProvider()
 
-	zlog.InitLogger("/tmp/mylog.log", "warn", zlog.WithCompress(true),
-		zlog.WithMaxAge(3), zlog.WithMaxBackups(3), zlog.WithMaxSize(1))
+	if err := zlog.InitLogger(
+		zlog.WithFile("/tmp/zaplog-noContext.log"),
+		zlog.WithStdout(),
+		zlog.WithLevel("warn"),
+		zlog.WithMaxSize(1),
+		zlog.WithMaxBackups(3),
+		zlog.WithMaxAge(3),
+		zlog.WithCompress(true),
+	); err != nil {
+		log.Fatal(err)
+	}
+	defer zlog.Sync()
+
 	go func() {
 		for {
 			atomic.AddUint64(&ops1, 1)
-
+			// Dropped: level is warn.
 			zlog.Info("test info1", zap.Uint64("ops", atomic.LoadUint64(&ops1)))
 			zlog.Warn("test warn1", zap.Uint64("ops", atomic.LoadUint64(&ops1)))
 			zlog.Error("test error1", zap.Uint64("ops", atomic.LoadUint64(&ops1)))
 			time.Sleep(200 * time.Millisecond)
 		}
-
 	}()
 	go func() {
 		for {
 			atomic.AddUint64(&ops2, 1)
-
-			zlog.Info("test info2", zap.Uint64("ops", atomic.LoadUint64(&ops2)))
 			zlog.Warn("test warn2", zap.Uint64("ops", atomic.LoadUint64(&ops2)))
 			zlog.Error("test error2", zap.Uint64("ops", atomic.LoadUint64(&ops2)))
 			time.Sleep(200 * time.Millisecond)
@@ -46,23 +59,19 @@ func main() {
 	}()
 
 	http.Handle("/metrics", promhttp.Handler())
-	fmt.Println("starting...")
-	// http://localhost:9090/metrics
-	http.ListenAndServe(":9090", nil)
+	fmt.Println("metrics: http://localhost:9090/metrics")
+	log.Fatal(http.ListenAndServe(":9090", nil))
 }
 
-func InitMeterProvider() *sdkmetric.MeterProvider {
-	promExporter, err := otelProm.New(otelProm.WithNamespace("otel-metrics"),
+func initMeterProvider() *sdkmetric.MeterProvider {
+	promExporter, err := otelProm.New(
+		otelProm.WithNamespace("otel-metrics"),
 		otelProm.WithRegisterer(prometheus.DefaultRegisterer),
 	)
 	if err != nil {
 		panic(err)
 	}
-	mp := sdkmetric.NewMeterProvider(
-		sdkmetric.WithReader(promExporter),
-		//sdkmetric.WithResource(initResource()),
-	)
+	mp := sdkmetric.NewMeterProvider(sdkmetric.WithReader(promExporter))
 	otel.SetMeterProvider(mp)
-
 	return mp
 }

--- a/example/teeJSON/main.go
+++ b/example/teeJSON/main.go
@@ -1,0 +1,36 @@
+// Container-style setup: JSON logs to stdout, optionally also to a file (tee).
+//
+//	go run ./example/teeJSON
+package main
+
+import (
+	"os"
+	"path/filepath"
+
+	zlog "github.com/vearne/zaplog"
+	"go.uber.org/zap"
+)
+
+func main() {
+	logPath := filepath.Join(os.TempDir(), "zaplog-example", "tee.log")
+
+	// Explicit sinks: once any WithFile/WithStdout/WithStderr is set,
+	// only those sinks are used (no implicit default stdout).
+	if err := zlog.InitLogger(
+		zlog.WithFile(logPath),
+		zlog.WithStdout(),
+		zlog.WithJSON(),
+		zlog.WithLevel("info"),
+	); err != nil {
+		panic(err)
+	}
+	defer zlog.Sync()
+
+	zlog.Info("json log to file and stdout",
+		zap.String("service", "api"),
+		zap.Int("port", 8080),
+	)
+	zlog.Warn("json warn", zap.Strings("tags", []string{"tee", "json"}))
+
+	println("also wrote to", logPath)
+}

--- a/example/withContext/main.go
+++ b/example/withContext/main.go
@@ -1,3 +1,7 @@
+// Context-aware logging with trace_id injection and auto span events.
+//
+//	go run ./example/withContext
+//	curl http://localhost:9090/metrics | grep log_total
 package main
 
 import (
@@ -21,99 +25,82 @@ import (
 	"go.uber.org/zap"
 )
 
-var ops1 uint64
-
-//var ops2 uint64
+var ops uint64
 
 func main() {
-	InitTracerProvider()
-	InitMeterProvider()
+	initTracerProvider()
+	initMeterProvider()
 
-	zlog.InitLogger("/tmp/withContext.log", "debug",
-		zlog.WithCompress(false),
-		zlog.WithMaxAge(3),
-		zlog.WithMaxBackups(3),
-		zlog.WithMaxSize(1),
+	if err := zlog.InitLogger(
+		zlog.WithFile("/tmp/zaplog-withContext.log"),
+		zlog.WithStdout(),
+		zlog.WithLevel("debug"),
 		zlog.WithTraceID(true),
 		zlog.WithAutoEvents(true),
-	)
+		zlog.WithMaxSize(1),
+		zlog.WithMaxBackups(3),
+		zlog.WithMaxAge(3),
+	); err != nil {
+		log.Fatal(err)
+	}
+	defer zlog.Sync()
 
 	go func() {
-		//logger1 := zlog.Named("worker1")
+		tracer := otel.GetTracerProvider().Tracer("zaplog-example")
 		for {
-			atomic.AddUint64(&ops1, 1)
-			ctx, span := otel.GetTracerProvider().Tracer("test").Start(context.Background(),
-				fmt.Sprintf("test:%v", atomic.LoadUint64(&ops1)))
-			zlog.InfoContext(ctx, "test info1", zap.Uint64("ops", atomic.LoadUint64(&ops1)))
-			zlog.InfoContext(ctx, "test info2",
-				zap.Any("testAny", struct {
+			n := atomic.AddUint64(&ops, 1)
+			ctx, span := tracer.Start(context.Background(), fmt.Sprintf("work:%d", n))
+
+			zlog.InfoContext(ctx, "traced info",
+				zap.Uint64("ops", n),
+				zap.Any("user", struct {
 					Age  int
 					Name string
-				}{Age: 12, Name: "testName"}))
-			zlog.WarnContext(ctx, "test warn1", zap.Strings("strs", []string{"aaa", "bbb", "ccc"}),
-				zap.Uint64("ops", atomic.LoadUint64(&ops1)))
-			//zlog.ErrorContext(ctx, "test error1", zap.Uint64("ops", atomic.LoadUint64(&ops1)))
+				}{Age: 12, Name: "alice"}),
+			)
+			zlog.WarnContext(ctx, "traced warn",
+				zap.Strings("tags", []string{"otel", "trace"}),
+				zap.Uint64("ops", n),
+			)
 			span.End()
-
-			time.Sleep(200 * time.Millisecond)
-		}
-
-	}()
-	go func() {
-		//logger2 := zlog.Named("worker2")
-		ctx := context.Background()
-		for {
-			atomic.AddUint64(&ops1, 1)
-			zlog.InfoContext(ctx, "test info2", zap.Uint64("ops", atomic.LoadUint64(&ops1)))
-			zlog.WarnContext(ctx, "test warn2", zap.Uint64("ops", atomic.LoadUint64(&ops1)))
-			zlog.ErrorContext(ctx, "test error2", zap.Uint64("ops", atomic.LoadUint64(&ops1)))
 			time.Sleep(200 * time.Millisecond)
 		}
 	}()
 
 	http.Handle("/metrics", promhttp.Handler())
-	fmt.Println("starting...")
-	// http://localhost:9090/metrics
-	http.ListenAndServe(":9090", nil)
+	fmt.Println("metrics: http://localhost:9090/metrics")
+	log.Fatal(http.ListenAndServe(":9090", nil))
 }
 
-func InitMeterProvider() *sdkmetric.MeterProvider {
-	promExporter, err := otelProm.New(otelProm.WithNamespace("otel-metrics"),
+func initMeterProvider() *sdkmetric.MeterProvider {
+	promExporter, err := otelProm.New(
+		otelProm.WithNamespace("otel-metrics"),
 		otelProm.WithRegisterer(prometheus.DefaultRegisterer),
 	)
 	if err != nil {
 		panic(err)
 	}
-	mp := sdkmetric.NewMeterProvider(
-		sdkmetric.WithReader(promExporter),
-	)
+	mp := sdkmetric.NewMeterProvider(sdkmetric.WithReader(promExporter))
 	otel.SetMeterProvider(mp)
-
 	return mp
 }
 
-func InitTracerProvider() *sdktrace.TracerProvider {
+func initTracerProvider() *sdktrace.TracerProvider {
 	ctx := context.Background()
 
-	// Create stdout exporter for debugging
 	stdoutExporter, err := stdouttrace.New(stdouttrace.WithWriter(os.Stderr))
 	if err != nil {
-		log.Fatalf("failed to create stdout exporter: %v", err)
+		log.Fatalf("stdout trace exporter: %v", err)
 	}
 
-	// Create OTLP HTTP exporter for production
 	httpExporter, err := otlptracehttp.New(ctx, otlptracehttp.WithInsecure())
 	if err != nil {
-		log.Printf("failed to create OTLP HTTP exporter: %v (continuing with stdout only)", err)
-		// Use only stdout exporter if OTLP fails
-		tp := sdktrace.NewTracerProvider(
-			sdktrace.WithSyncer(stdoutExporter),
-		)
+		log.Printf("OTLP exporter unavailable (%v); using stdout only", err)
+		tp := sdktrace.NewTracerProvider(sdktrace.WithSyncer(stdoutExporter))
 		otel.SetTracerProvider(tp)
 		return tp
 	}
 
-	// Use both exporters: stdout (sync) and OTLP (batched)
 	tp := sdktrace.NewTracerProvider(
 		sdktrace.WithSyncer(stdoutExporter),
 		sdktrace.WithBatcher(httpExporter),

--- a/option.go
+++ b/option.go
@@ -6,9 +6,63 @@ type Config struct {
 	lumberjack.Logger
 	WithTraceID    bool
 	WithAutoEvents bool
+	// CallerSkip is the number of additional stack frames to skip when
+	// reporting the caller. Default is 1 (skip zaplog's own Info/Debug/... wrappers).
+	// Increase by 1 for each extra wrapper layer around zaplog.
+	CallerSkip int
+
+	Level string
+
+	// Output sinks. If none are set, InitLogger defaults to stdout.
+	FilePath   string
+	AlsoStdout bool
+	AlsoStderr bool
+	outputSet  bool // true if any WithFile/WithStdout/WithStderr was used
+
+	JSON bool
 }
 
 type Option func(c *Config)
+
+// WithLevel sets the minimum log level. Supported: debug, info, warn, error.
+// Default is "info".
+func WithLevel(level string) Option {
+	return func(c *Config) {
+		c.Level = level
+	}
+}
+
+// WithFile enables file output at path (lumberjack rotation).
+func WithFile(path string) Option {
+	return func(c *Config) {
+		c.FilePath = path
+		c.Filename = path
+		c.outputSet = true
+	}
+}
+
+// WithStdout enables writing logs to os.Stdout.
+func WithStdout() Option {
+	return func(c *Config) {
+		c.AlsoStdout = true
+		c.outputSet = true
+	}
+}
+
+// WithStderr enables writing logs to os.Stderr.
+func WithStderr() Option {
+	return func(c *Config) {
+		c.AlsoStderr = true
+		c.outputSet = true
+	}
+}
+
+// WithJSON switches the encoder from console to JSON.
+func WithJSON() Option {
+	return func(c *Config) {
+		c.JSON = true
+	}
+}
 
 // megabytes
 func WithMaxSize(maxSize int) Option {
@@ -36,7 +90,7 @@ func WithCompress(compress bool) Option {
 	}
 }
 
-// WithTraceIDField configures the logger to add `trace_id` field to structured log messages.
+// WithTraceID configures the logger to add `trace_id` field to structured log messages.
 func WithTraceID(on bool) Option {
 	return func(c *Config) {
 		c.WithTraceID = on
@@ -48,5 +102,14 @@ func WithTraceID(on bool) Option {
 func WithAutoEvents(enable bool) Option {
 	return func(c *Config) {
 		c.WithAutoEvents = enable
+	}
+}
+
+// WithCallerSkip sets how many extra stack frames to skip when annotating logs with caller
+// file:line. The default is 1 so direct zaplog.Info/Debug/... calls report the application
+// call site. Pass 2 if you wrap zaplog in another package (e.g. applog.Info -> zaplog.Info).
+func WithCallerSkip(skip int) Option {
+	return func(c *Config) {
+		c.CallerSkip = skip
 	}
 }

--- a/zaplog.go
+++ b/zaplog.go
@@ -4,6 +4,9 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/uptrace/opentelemetry-go-extra/otelzap"
@@ -18,70 +21,164 @@ import (
 const LabelLevel = "level"
 
 var (
-	DefaultLogger *otelzap.Logger
+	// DefaultLogger is never nil: before InitLogger it discards all logs (zap.NewNop).
+	DefaultLogger = otelzap.New(zap.NewNop())
 	zapLogConfig  Config
+	atomicLevel   zap.AtomicLevel
 )
 
 func GetDefaultLogger() *otelzap.Logger {
 	return DefaultLogger
 }
 
-func InitLogger(logPath string, level string, opts ...Option) {
-	alevel := zap.NewAtomicLevel()
-
+// InitLogger initializes the default logger.
+//
+// Defaults when called with no options:
+//   - level: info
+//   - output: stdout
+//
+// Examples:
+//
+//	InitLogger()
+//	InitLogger(WithFile("/var/log/app.log"))
+//	InitLogger(WithFile(path), WithStdout(), WithLevel("debug"), WithJSON())
+func InitLogger(opts ...Option) error {
 	zapLogConfig = Config{
 		Logger: lumberjack.Logger{
-			Filename:   logPath,
 			MaxSize:    1024, // megabytes
 			MaxBackups: 3,
-			MaxAge:     7,     //days
-			Compress:   false, // disabled by default
+			MaxAge:     7, // days
+			Compress:   false,
 		},
 		WithTraceID:    false,
 		WithAutoEvents: true,
+		CallerSkip:     1,
+		Level:          "info",
 	}
 
 	for _, opt := range opts {
 		opt(&zapLogConfig)
 	}
 
-	w := zapcore.AddSync(&zapLogConfig)
+	if !zapLogConfig.outputSet {
+		zapLogConfig.AlsoStdout = true
+	}
 
-	switch level {
-	case "debug":
-		alevel.SetLevel(zap.DebugLevel)
-	case "info":
-		alevel.SetLevel(zap.InfoLevel)
-	case "warn":
-		alevel.SetLevel(zap.WarnLevel)
-	case "error":
-		alevel.SetLevel(zap.ErrorLevel)
-	default:
-		alevel.SetLevel(zap.InfoLevel)
+	if zapLogConfig.FilePath != "" {
+		if err := ensureLogDir(zapLogConfig.FilePath); err != nil {
+			return err
+		}
+		zapLogConfig.Filename = zapLogConfig.FilePath
+	}
+
+	if zapLogConfig.FilePath == "" && !zapLogConfig.AlsoStdout && !zapLogConfig.AlsoStderr {
+		return fmt.Errorf("zaplog: no output configured")
+	}
+
+	atomicLevel = zap.NewAtomicLevel()
+	if err := applyLevel(zapLogConfig.Level); err != nil {
+		return err
+	}
+
+	callerSkip := zapLogConfig.CallerSkip
+	if callerSkip < 0 {
+		callerSkip = 0
 	}
 
 	encoderConfig := zap.NewProductionEncoderConfig()
 	encoderConfig.EncodeTime = zapcore.TimeEncoderOfLayout(time.DateTime)
 	encoderConfig.ConsoleSeparator = " | "
 
-	core := zapcore.NewCore(
-		zapcore.NewConsoleEncoder(encoderConfig),
-		w,
-		alevel,
-	)
+	var encoder zapcore.Encoder
+	if zapLogConfig.JSON {
+		encoder = zapcore.NewJSONEncoder(encoderConfig)
+	} else {
+		encoder = zapcore.NewConsoleEncoder(encoderConfig)
+	}
 
-	logger := zap.New(core)
-	logger = logger.WithOptions(zap.AddCaller(), zap.AddCallerSkip(1))
+	var cores []zapcore.Core
+	if zapLogConfig.FilePath != "" {
+		cores = append(cores, zapcore.NewCore(encoder.Clone(), zapcore.AddSync(&zapLogConfig), atomicLevel))
+	}
+	if zapLogConfig.AlsoStdout {
+		cores = append(cores, zapcore.NewCore(encoder.Clone(), zapcore.AddSync(os.Stdout), atomicLevel))
+	}
+	if zapLogConfig.AlsoStderr {
+		cores = append(cores, zapcore.NewCore(encoder.Clone(), zapcore.AddSync(os.Stderr), atomicLevel))
+	}
+
+	logger := zap.New(zapcore.NewTee(cores...))
+	logger = logger.WithOptions(zap.AddCaller(), zap.AddCallerSkip(callerSkip))
 
 	DefaultLogger = otelzap.New(logger,
 		otelzap.WithMinLevel(zap.DebugLevel),
-		otelzap.WithCallerDepth(1),
-		otelzap.WithErrorStatusLevel(zap.ErrorLevel), // Error 日志设置 span 状态为 Error
+		otelzap.WithCallerDepth(callerSkip),
+		otelzap.WithErrorStatusLevel(zap.ErrorLevel),
 	)
+	return nil
+}
+
+// SetLevel changes the minimum log level at runtime.
+// Supported: debug, info, warn, error. Must be called after InitLogger.
+func SetLevel(level string) error {
+	return applyLevel(level)
+}
+
+// Level returns the current minimum log level.
+func Level() zapcore.Level {
+	return atomicLevel.Level()
+}
+
+// AtomicLevel returns the underlying zap.AtomicLevel for advanced use.
+func AtomicLevel() zap.AtomicLevel {
+	return atomicLevel
+}
+
+// Sync flushes any buffered log entries. Call before process exit.
+func Sync() error {
+	return DefaultLogger.Sync()
+}
+
+func applyLevel(level string) error {
+	switch strings.ToLower(strings.TrimSpace(level)) {
+	case "", "info":
+		atomicLevel.SetLevel(zap.InfoLevel)
+	case "debug":
+		atomicLevel.SetLevel(zap.DebugLevel)
+	case "warn", "warning":
+		atomicLevel.SetLevel(zap.WarnLevel)
+	case "error":
+		atomicLevel.SetLevel(zap.ErrorLevel)
+	default:
+		return fmt.Errorf("zaplog: unknown level %q", level)
+	}
+	return nil
+}
+
+// ensureLogDir validates logPath and creates its parent directory when missing.
+func ensureLogDir(logPath string) error {
+	if strings.TrimSpace(logPath) == "" {
+		return fmt.Errorf("zaplog: log path is empty")
+	}
+	dir := filepath.Dir(logPath)
+	fi, err := os.Stat(dir)
+	if err == nil {
+		if !fi.IsDir() {
+			return fmt.Errorf("zaplog: log path parent is not a directory: %s", dir)
+		}
+		return nil
+	}
+	if !os.IsNotExist(err) {
+		return fmt.Errorf("zaplog: stat log dir: %w", err)
+	}
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("zaplog: create log dir: %w", err)
+	}
+	return nil
 }
 
 func statistics(level zapcore.Level) {
-	if DefaultLogger.Level() >= level {
+	if DefaultLogger.Core().Enabled(level) {
 		logTotal.Add(context.Background(),
 			1,
 			metric.WithAttributes(
@@ -101,6 +198,11 @@ func tryAddFields(ctx context.Context, fields []zapcore.Field) []zapcore.Field {
 	return fields
 }
 
+// Named returns a child logger with the given name.
+//
+// Logs written through the returned *otelzap.Logger bypass zaplog package
+// helpers: they do NOT go through statistics / trace_id injection / auto span
+// events. Use package-level Info/InfoContext/... when you need those features.
 func Named(s string) *otelzap.Logger {
 	l := DefaultLogger.Clone()
 	l.Logger = l.Logger.Named(s)
@@ -137,6 +239,7 @@ func zapFieldsToAttributes(fields []zapcore.Field) []attribute.KeyValue {
 	}
 	return attrs
 }
+
 func addEventIfEnabled(ctx context.Context, level, msg string, fields ...zapcore.Field) {
 	if zapLogConfig.WithAutoEvents {
 		span := trace.SpanFromContext(ctx)

--- a/zaplog_test.go
+++ b/zaplog_test.go
@@ -1,0 +1,167 @@
+package zaplog
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/uptrace/opentelemetry-go-extra/otelzap"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+)
+
+func TestDefaultLoggerNeverNil(t *testing.T) {
+	DefaultLogger = otelzap.New(zap.NewNop())
+	Info("before init should not panic")
+}
+
+func TestInitLoggerDefaults(t *testing.T) {
+	if err := InitLogger(); err != nil {
+		t.Fatal(err)
+	}
+	if Level() != zapcore.InfoLevel {
+		t.Fatalf("default level: got %v want info", Level())
+	}
+	if !zapLogConfig.AlsoStdout {
+		t.Fatal("expected default stdout output")
+	}
+	if zapLogConfig.FilePath != "" {
+		t.Fatal("expected no file by default")
+	}
+}
+
+func TestInitLoggerEmptyFilePath(t *testing.T) {
+	if err := InitLogger(WithFile("")); err == nil {
+		t.Fatal("expected error for empty file path")
+	}
+	if err := InitLogger(WithFile("   ")); err == nil {
+		t.Fatal("expected error for blank file path")
+	}
+}
+
+func TestInitLoggerCreatesParentDir(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "nested", "logs")
+	path := filepath.Join(dir, "app.log")
+	if err := InitLogger(WithFile(path), WithLevel("debug")); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(dir); err != nil {
+		t.Fatalf("expected log dir to exist: %v", err)
+	}
+	Info("mkdir ok")
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("expected log file to exist: %v", err)
+	}
+	if zapLogConfig.AlsoStdout {
+		t.Fatal("WithFile alone should not enable stdout")
+	}
+}
+
+func TestInitLoggerFileAndStdout(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "app.log")
+	if err := InitLogger(WithFile(path), WithStdout()); err != nil {
+		t.Fatal(err)
+	}
+	if !zapLogConfig.AlsoStdout || zapLogConfig.FilePath == "" {
+		t.Fatal("expected both file and stdout")
+	}
+}
+
+func TestSetLevel(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "app.log")
+	if err := InitLogger(WithFile(path), WithLevel("info")); err != nil {
+		t.Fatal(err)
+	}
+	Debug("should be dropped")
+	if err := SetLevel("debug"); err != nil {
+		t.Fatal(err)
+	}
+	Debug("should be kept")
+	_ = Sync()
+
+	got := mustRead(t, path)
+	if strings.Contains(got, "should be dropped") {
+		t.Fatalf("debug before SetLevel should be dropped, got:\n%s", got)
+	}
+	if !strings.Contains(got, "should be kept") {
+		t.Fatalf("debug after SetLevel should be kept, got:\n%s", got)
+	}
+}
+
+func TestWithJSON(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "app.log")
+	if err := InitLogger(WithFile(path), WithJSON(), WithLevel("info")); err != nil {
+		t.Fatal(err)
+	}
+	Info("json line")
+	_ = Sync()
+	got := mustRead(t, path)
+	if !strings.Contains(got, `"msg":"json line"`) && !strings.Contains(got, `"message":"json line"`) {
+		// production encoder uses "msg"
+		if !strings.Contains(got, "json line") || !strings.Contains(got, "{") {
+			t.Fatalf("expected JSON log, got:\n%s", got)
+		}
+	}
+}
+
+func TestCallerSkipDefaultReportsCallSite(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "app.log")
+	if err := InitLogger(WithFile(path), WithLevel("debug")); err != nil {
+		t.Fatal(err)
+	}
+
+	_, _, line, _ := runtime.Caller(0)
+	Info("caller skip default")
+	wantLine := line + 1
+
+	got := mustRead(t, path)
+	want := fmt.Sprintf("zaplog_test.go:%d", wantLine)
+	if !strings.Contains(got, want) {
+		t.Fatalf("want %q in log, got:\n%s", want, got)
+	}
+	if strings.Contains(got, "zaplog.go:") {
+		t.Fatalf("caller should skip zaplog wrapper, got:\n%s", got)
+	}
+}
+
+func TestCallerSkipExtraWrapper(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "app.log")
+	if err := InitLogger(WithFile(path), WithLevel("debug"), WithCallerSkip(2)); err != nil {
+		t.Fatal(err)
+	}
+
+	_, _, line, _ := runtime.Caller(0)
+	extraWrapperInfo()
+	wantLine := line + 1
+
+	got := mustRead(t, path)
+	want := fmt.Sprintf("zaplog_test.go:%d", wantLine)
+	if !strings.Contains(got, want) {
+		t.Fatalf("want %q in log with skip=2, got:\n%s", want, got)
+	}
+	if strings.Contains(got, "zaplog.go:") {
+		t.Fatalf("caller should skip both wrappers, got:\n%s", got)
+	}
+}
+
+func TestUnknownLevel(t *testing.T) {
+	if err := InitLogger(WithStdout(), WithLevel("verbose")); err == nil {
+		t.Fatal("expected error for unknown level")
+	}
+}
+
+func extraWrapperInfo() {
+	Info("caller skip with extra wrapper")
+}
+
+func mustRead(t *testing.T, path string) string {
+	t.Helper()
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(b)
+}


### PR DESCRIPTION
Support zero-arg InitLogger (default info+stdout), WithFile/Stdout/JSON, runtime SetLevel/Sync, fix metrics level gating, and expand usage examples.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Configure logging with options for level, file output, stdout/stderr, JSON formatting, caller details, and log rotation.
  * Change log levels at runtime and flush buffered logs with new controls.
  * File logging now creates missing directories automatically and supports combined output destinations.
  * Added runnable examples for basic, file, JSON, context-aware, and metrics-enabled logging.

* **Documentation**
  * Refreshed the README and added expanded setup guidance, configuration references, and example walkthroughs.

* **Bug Fixes**
  * Logging is safe to use before initialization through a no-op default logger.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->